### PR TITLE
Updated GetHeaderInfo for encapsulaed TSes

### DIFF
--- a/Source/MediaStorageAndFileFormat/mdcmBitmap.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmBitmap.cxx
@@ -562,7 +562,6 @@ Bitmap::TryJPEGCodec(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
       {
@@ -575,9 +574,9 @@ Bitmap::TryJPEGCodec(char * buffer, bool & lossyflag) const
       codec.SetPixelFormat(pf);
       std::stringstream ss;
       ss.write(bv2.GetPointer(), bv2.GetLength());
-      if (!codec.GetHeaderInfo(ss, ts2))
+      if (!codec.GetHeaderInfo(ss))
       {
-        mdcmAlwaysWarnMacro("JPEG: !codec.GetHeaderInfo(ss, ts2)");
+        mdcmAlwaysWarnMacro("JPEG: !codec.GetHeaderInfo(ss)");
         return false;
       }
       lossyflag = codec.IsLossy();
@@ -747,7 +746,6 @@ Bitmap::TryJPEGCodec3(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
       {
@@ -760,9 +758,9 @@ Bitmap::TryJPEGCodec3(char * buffer, bool & lossyflag) const
       codec.SetPixelFormat(pf);
       std::stringstream ss;
       ss.write(bv2.GetPointer(), bv2.GetLength());
-      if (!codec.GetHeaderInfo(ss, ts2))
+      if (!codec.GetHeaderInfo(ss))
       {
-        mdcmAlwaysWarnMacro("JPEG: !codec.GetHeaderInfo(ss, ts2)");
+        mdcmAlwaysWarnMacro("JPEG: !codec.GetHeaderInfo(ss)");
         return false;
       }
       lossyflag = codec.IsLossy();
@@ -923,7 +921,6 @@ Bitmap::TryJPEGLSCodec(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
         return false;
@@ -931,7 +928,7 @@ Bitmap::TryJPEGLSCodec(char * buffer, bool & lossyflag) const
       const ByteValue & bv2 = dynamic_cast<const ByteValue &>(frag.GetValue());
       std::stringstream ss;
       ss.write(bv2.GetPointer(), bv2.GetLength());
-      const bool b = codec.GetHeaderInfo(ss, ts2);
+      const bool b = codec.GetHeaderInfo(ss);
       if (!b)
         return false;
       lossyflag = codec.IsLossy();
@@ -983,7 +980,6 @@ Bitmap::TryJPEGLSCodec2(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
         return false;
@@ -991,7 +987,7 @@ Bitmap::TryJPEGLSCodec2(char * buffer, bool & lossyflag) const
       const ByteValue & bv2 = dynamic_cast<const ByteValue &>(frag.GetValue());
       std::stringstream ss;
       ss.write(bv2.GetPointer(), bv2.GetLength());
-      const bool b = codec.GetHeaderInfo(ss, ts2);
+      const bool b = codec.GetHeaderInfo(ss);
       if (!b)
         return false;
       lossyflag = codec.IsLossy();
@@ -1032,13 +1028,12 @@ Bitmap::TryJPEG2000Codec(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
         return false;
       const Fragment &  frag = sf->GetFragment(0);
       const ByteValue & bv2 = dynamic_cast<const ByteValue &>(frag.GetValue());
-      const bool        b = codec.GetHeaderInfo(bv2.GetPointer(), bv2.GetLength(), ts2);
+      const bool        b = codec.GetHeaderInfo(bv2.GetPointer(), bv2.GetLength());
       if (!b)
         return false;
       lossyflag = codec.IsLossy();
@@ -1158,13 +1153,12 @@ Bitmap::TryJPEG2000Codec3(char * buffer, bool & lossyflag) const
   {
     if (codec.CanDecode(ts))
     {
-      TransferSyntax              ts2;
       const SequenceOfFragments * sf = PixelData.GetSequenceOfFragments();
       if (!sf)
         return false;
       const Fragment &  frag = sf->GetFragment(0);
       const ByteValue & bv2 = dynamic_cast<const ByteValue &>(frag.GetValue());
-      const bool        b = codec.GetHeaderInfo(bv2.GetPointer(), bv2.GetLength(), ts2);
+      const bool        b = codec.GetHeaderInfo(bv2.GetPointer(), bv2.GetLength());
       if (!b)
         return false;
       lossyflag = codec.IsLossy();

--- a/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.cxx
@@ -134,9 +134,13 @@ EncapsulatedRAWCodec::Decode2(DataElement const & in, char * out_buffer, unsigne
 }
 
 bool
-EncapsulatedRAWCodec::GetHeaderInfo(std::istream &, TransferSyntax & ts)
+EncapsulatedRAWCodec::GetHeaderInfo(std::istream &)
 {
+  // Removed guessing transfer syntax by header (unused),
+  // commented for possible future implementation.
+  /*
   ts = TransferSyntax::EncapsulatedUncompressedExplicitVRLittleEndian;
+  */
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.h
@@ -30,7 +30,7 @@ public:
   bool
   Decode2(DataElement const &, char *, unsigned long long);
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
   bool
   DecodeBytes(const char *, size_t, char *, size_t);
 

--- a/Source/MediaStorageAndFileFormat/mdcmIconImageFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmIconImageFilter.cxx
@@ -276,7 +276,7 @@ IconImageFilter::ExtractIconImages()
       TransferSyntax jpegts;
       JPEGCodec      jpeg;
       jpeg.SetPixelFormat(pf1);
-      bool b = jpeg.GetHeaderInfo(is, jpegts);
+      bool b = jpeg.GetHeaderInfoAndTS(is, jpegts);
       if (!b)
       {
         assert(0);

--- a/Source/MediaStorageAndFileFormat/mdcmImageCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmImageCodec.cxx
@@ -92,7 +92,7 @@ ImageCodec::GetLossyFlag() const
 }
 
 bool
-ImageCodec::GetHeaderInfo(std::istream &, TransferSyntax &)
+ImageCodec::GetHeaderInfo(std::istream &)
 {
   assert(0);
   return false;

--- a/Source/MediaStorageAndFileFormat/mdcmImageCodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmImageCodec.h
@@ -37,8 +37,6 @@ namespace mdcm
  */
 class MDCM_EXPORT ImageCodec
 {
-  friend class FileChangeTransferSyntax;
-
 public:
   ImageCodec();
   virtual ~ImageCodec();
@@ -57,7 +55,7 @@ public:
   bool
   GetLossyFlag() const;
   virtual bool
-  GetHeaderInfo(std::istream &, TransferSyntax &);
+  GetHeaderInfo(std::istream &);
   unsigned int
   GetPlanarConfiguration() const;
   void

--- a/Source/MediaStorageAndFileFormat/mdcmJPEG12Codec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEG12Codec.h
@@ -43,7 +43,9 @@ public:
   bool
   InternalCode(const char *, size_t, std::ostream &) override;
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
+  bool
+  GetHeaderInfoAndTS(std::istream &, TransferSyntax &);
 
 protected:
   bool

--- a/Source/MediaStorageAndFileFormat/mdcmJPEG16Codec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEG16Codec.h
@@ -43,7 +43,9 @@ public:
   bool
   InternalCode(const char *, size_t, std::ostream &) override;
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
+  bool
+  GetHeaderInfoAndTS(std::istream &, TransferSyntax &);
 
 protected:
   bool

--- a/Source/MediaStorageAndFileFormat/mdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEG2000Codec.cxx
@@ -734,13 +734,13 @@ JPEG2000Codec::CanDecode(TransferSyntax const & ts) const
 {
   return (ts == TransferSyntax::JPEG2000Lossless ||
           ts == TransferSyntax::JPEG2000 ||
-          //ts == TransferSyntax::HTJPEG2000Lossless ||
-          //ts == TransferSyntax::HTJPEG2000RPCLLossless ||
-          //ts == TransferSyntax::HTJPEG2000 ||
+          ts == TransferSyntax::HTJPEG2000Lossless ||
+          ts == TransferSyntax::HTJPEG2000RPCLLossless ||
+          ts == TransferSyntax::HTJPEG2000 ||
           ts == TransferSyntax::JPEG2000Part2Lossless ||
           ts == TransferSyntax::JPEG2000Part2);
-  // HT TODO
-  // Part 2 is not tested, TODO
+  // HT is not yet tested, TODO
+  // Part 2 is not tested, there are no examples available, TODO
 }
 
 bool
@@ -1083,7 +1083,7 @@ JPEG2000Codec::Code(DataElement const & in, DataElement & out)
 }
 
 bool
-JPEG2000Codec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
+JPEG2000Codec::GetHeaderInfo(std::istream & is)
 {
   is.seekg(0, std::ios::end);
   const size_t buf_size = is.tellg();
@@ -1098,7 +1098,7 @@ JPEG2000Codec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
   }
   is.seekg(0, std::ios::beg);
   is.read(dummy_buffer, buf_size);
-  const bool b = GetHeaderInfo(dummy_buffer, buf_size, ts);
+  const bool b = GetHeaderInfo(dummy_buffer, buf_size);
   delete[] dummy_buffer;
   return b;
 }
@@ -1859,7 +1859,7 @@ JPEG2000Codec::CodeFrameIntoBuffer(char *       outdata,
 }
 
 bool
-JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, TransferSyntax & ts)
+JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size)
 {
   if (!dummy_buffer)
     return false;
@@ -2048,39 +2048,48 @@ JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Transfe
   }
 #endif
   assert(PI != PhotometricInterpretation::UNKNOWN);
-  const bool bmct = false; // TODO
+  // FIXME
+  //
+  //
+  // Guessing PhotometricInterpretation by header should be reviewed.
+  //
+  // Removed guessing transfer syntax by header (unused),
+  // commented for possible future implementation.
+  // HT must be taken into acout too.
+  /*
+  // const bool bmct = false;
   if (bmct)
   {
     if (reversible)
     {
-      ts = TransferSyntax::JPEG2000Part2Lossless;
+      //ts = TransferSyntax::JPEG2000Part2Lossless;
     }
     else
     {
-      ts = TransferSyntax::JPEG2000Part2;
+      //ts = TransferSyntax::JPEG2000Part2;
       if (PI == PhotometricInterpretation::YBR_RCT)
       {
-        // TODO
         PI = PhotometricInterpretation::YBR_ICT;
       }
     }
   }
   else
+  */
   {
     if (reversible)
     {
-      ts = TransferSyntax::JPEG2000Lossless;
+      //ts = TransferSyntax::JPEG2000Lossless;
     }
     else
     {
-      ts = TransferSyntax::JPEG2000;
+      //ts = TransferSyntax::JPEG2000;
       if (PI == PhotometricInterpretation::YBR_RCT)
       {
-        // TODO
         PI = PhotometricInterpretation::YBR_ICT;
       }
     }
   }
+  /*
   if (this->GetPhotometricInterpretation().IsLossy())
   {
     assert(ts.IsLossy());
@@ -2089,6 +2098,11 @@ JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Transfe
   {
     assert(this->GetPhotometricInterpretation().IsLossless());
   }
+  */
+  //
+  //
+  //
+
   // Close the byte stream
   opj_stream_destroy(cio);
   // Free remaining structures

--- a/Source/MediaStorageAndFileFormat/mdcmJPEG2000Codec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEG2000Codec.h
@@ -51,7 +51,7 @@ public:
   bool
   Code(DataElement const &, DataElement &) override;
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
   void
   SetRate(unsigned int, double);
   double
@@ -104,7 +104,7 @@ private:
   bool
   CodeFrameIntoBuffer(char *, size_t, size_t &, const char *, size_t);
   bool
-  GetHeaderInfo(const char *, size_t, TransferSyntax &);
+  GetHeaderInfo(const char *, size_t);
   JPEG2000Internals * Internals;
 };
 

--- a/Source/MediaStorageAndFileFormat/mdcmJPEG8Codec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEG8Codec.h
@@ -43,7 +43,9 @@ public:
   bool
   InternalCode(const char *, size_t, std::ostream &) override;
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
+  bool
+  GetHeaderInfoAndTS(std::istream &, TransferSyntax &);
 
 protected:
   bool

--- a/Source/MediaStorageAndFileFormat/mdcmJPEGBITSCodec.hxx
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEGBITSCodec.hxx
@@ -440,7 +440,16 @@ JPEGBITSCodec::~JPEGBITSCodec()
 }
 
 bool
-JPEGBITSCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
+JPEGBITSCodec::GetHeaderInfo(std::istream & is)
+{
+  TransferSyntax ts;
+  const bool r = GetHeaderInfoAndTS(is, ts);
+  (void) ts;
+  return r;
+}
+
+bool
+JPEGBITSCodec::GetHeaderInfoAndTS(std::istream & is, TransferSyntax & ts)
 {
   /* This struct contains the JPEG decompression parameters and pointers to
    * working space (which is allocated as needed by the JPEG library).

--- a/Source/MediaStorageAndFileFormat/mdcmJPEGCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEGCodec.cxx
@@ -424,10 +424,19 @@ JPEGCodec::ComputeOffsetTable(bool)
 }
 
 bool
-JPEGCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
+JPEGCodec::GetHeaderInfo(std::istream & is)
 {
-  assert(Internal);
-  if (!Internal->GetHeaderInfo(is, ts))
+  TransferSyntax ts;
+  const bool r = GetHeaderInfoAndTS(is, ts);
+  (void) ts;
+  return r;
+}
+
+bool
+JPEGCodec::GetHeaderInfoAndTS(std::istream & is, TransferSyntax & ts)
+{
+  if (!Internal) return false;
+  if (!Internal->GetHeaderInfoAndTS(is, ts))
   {
     // check if this is one of those buggy lossless JPEG
     if (this->BitSample != Internal->BitSample)
@@ -436,7 +445,7 @@ JPEGCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
       // PHILIPS_Gyroscan-12-MONO2-Jpeg_Lossless.dcm
       is.seekg(0, std::ios::beg);
       SetupJPEGBitCodec(Internal->BitSample);
-      if (Internal && Internal->GetHeaderInfo(is, ts))
+      if (Internal && Internal->GetHeaderInfoAndTS(is, ts))
       {
         this->SetLossyFlag(Internal->GetLossyFlag());
         this->SetDimensions(Internal->GetDimensions());

--- a/Source/MediaStorageAndFileFormat/mdcmJPEGCodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEGCodec.h
@@ -57,7 +57,9 @@ public:
   void
   ComputeOffsetTable(bool);
   virtual bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
+  virtual bool
+  GetHeaderInfoAndTS(std::istream &, TransferSyntax &);
   void
   SetQuality(double);
   double

--- a/Source/MediaStorageAndFileFormat/mdcmJPEGLSCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEGLSCodec.cxx
@@ -312,7 +312,7 @@ JPEGLSCodec::SetBufferLength(unsigned long long l)
 }
 
 bool
-JPEGLSCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
+JPEGLSCodec::GetHeaderInfo(std::istream & is)
 {
   using namespace charls;
   is.seekg(0, std::ios::end);
@@ -367,6 +367,9 @@ JPEGLSCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
   }
   // allowedlossyerror == 0 => Lossless
   LossyFlag = metadata.allowedLossyError != 0;
+  // Removed guessing transfer syntax by header (unused),
+  // commented for possible future implementation.
+  /*
   if (metadata.allowedLossyError == 0)
   {
     ts = TransferSyntax::JPEGLSLossless;
@@ -375,6 +378,7 @@ JPEGLSCodec::GetHeaderInfo(std::istream & is, TransferSyntax & ts)
   {
     ts = TransferSyntax::JPEGLSNearLossless;
   }
+  */
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/mdcmJPEGLSCodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmJPEGLSCodec.h
@@ -53,7 +53,7 @@ public:
   void
   SetBufferLength(unsigned long long);
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
   void
   SetLossless(bool);
   bool

--- a/Source/MediaStorageAndFileFormat/mdcmPixmapReader.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmPixmapReader.cxx
@@ -907,8 +907,7 @@ PixmapReader::ReadImageInternal(const MediaStorage & ms, bool handlepixeldata)
         sqf->WriteBuffer(ss);
         PixelFormat jpegpf(PixelFormat::UINT8); // guess
         jpeg.SetPixelFormat(jpegpf);
-        TransferSyntax ts;
-        bool           b = jpeg.GetHeaderInfo(ss, ts);
+        const bool b = jpeg.GetHeaderInfo(ss);
         if (b)
         {
           std::vector<unsigned int> v(3);

--- a/Source/MediaStorageAndFileFormat/mdcmRAWCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmRAWCodec.cxx
@@ -154,13 +154,17 @@ RAWCodec::Decode(DataElement const & in, DataElement & out)
 }
 
 bool
-RAWCodec::GetHeaderInfo(std::istream &, TransferSyntax & ts)
+RAWCodec::GetHeaderInfo(std::istream &)
 {
+  // Removed guessing transfer syntax by header (unused),
+  // commented for possible future implementation.
+  /*
   ts = TransferSyntax::ExplicitVRLittleEndian;
   if (NeedByteSwap)
   {
     ts = TransferSyntax::ImplicitVRBigEndianPrivateGE;
   }
+  */
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/mdcmRAWCodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmRAWCodec.h
@@ -43,7 +43,7 @@ public:
   bool
   Decode(DataElement const &, DataElement &) override;
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
   bool
   DecodeBytes(const char *, size_t, char *, size_t);
 

--- a/Source/MediaStorageAndFileFormat/mdcmRLECodec.cxx
+++ b/Source/MediaStorageAndFileFormat/mdcmRLECodec.cxx
@@ -699,9 +699,13 @@ RLECodec::SetBufferLength(unsigned long long l)
 }
 
 bool
-RLECodec::GetHeaderInfo(std::istream &, TransferSyntax & ts)
+RLECodec::GetHeaderInfo(std::istream &)
 {
+  // Removed guessing transfer syntax by header (unused),
+  // commented for possible future implementation.
+  /*
   ts = TransferSyntax::RLELossless;
+  */
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/mdcmRLECodec.h
+++ b/Source/MediaStorageAndFileFormat/mdcmRLECodec.h
@@ -59,7 +59,7 @@ public:
   void
   SetBufferLength(unsigned long long);
   bool
-  GetHeaderInfo(std::istream &, TransferSyntax &) override;
+  GetHeaderInfo(std::istream &) override;
   void
   SetLength(unsigned long long);
 


### PR DESCRIPTION
removed unused guess of transfer syntax by header (except for JPEG, it is used for GEIIS private icons). Mainly because it doesn't work with J2k, specially Part2 and HT. Maybe re-implemented later if requied, code is preserved (commented).